### PR TITLE
著作権の更新年を削除

### DIFF
--- a/_includes/themes/twitter/default.html
+++ b/_includes/themes/twitter/default.html
@@ -49,7 +49,7 @@
       </div>
 
       <footer>
-        <p>&copy; 2007-2023 <a href="{{ site.author.url }}">{{ site.author.name }}</a></p>
+        <p>&copy; 2007 <a href="{{ site.author.url }}">{{ site.author.name }}</a></p>
       </footer>
 
     </div> <!-- /container -->


### PR DESCRIPTION
著作権の更新年は表示が不要なので、今後更新する手間をなくすために削除しています。